### PR TITLE
fix: remove react-native-flipper dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "devDependencies": {
     "@heap/react-native-heap": "^0.20.0",
     "@types/lodash": "^4.14.182",
+    "react-native-flipper": "^0.146.1"
     "typescript": "^4.6.4"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.0",
-    "lodash": "^4.17.21",
-    "react-native-flipper": "^0.146.1"
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
Having `react-native-flipper` as a dependency on this package makes every project install old version of `react-native-flipper`. So it's better to remove it or add it as peer dependency potentially.